### PR TITLE
Add security packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,11 @@
         "express-async-errors": "^3.1.1",
         "express-favicon": "^2.0.4",
         "express-fileupload": "^1.4.0",
+        "express-mongo-sanitize": "^2.2.0",
+        "express-rate-limit": "^6.7.0",
         "fs": "^0.0.1-security",
         "handlebars": "^4.7.7",
+        "helmet": "^7.0.0",
         "http-status-codes": "^2.2.0",
         "jsonwebtoken": "^9.0.0",
         "mongoose": "^7.2.2",
@@ -30,7 +33,8 @@
         "nodemailer": "^6.9.2",
         "path": "^0.12.7",
         "stripe": "^12.10.0",
-        "validator": "^13.9.0"
+        "validator": "^13.9.0",
+        "xss-clean": "^0.1.4"
       },
       "devDependencies": {
         "nodemon": "^2.0.21"
@@ -694,6 +698,25 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express-mongo-sanitize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/express-mongo-sanitize/-/express-mongo-sanitize-2.2.0.tgz",
+      "integrity": "sha512-PZBs5nwhD6ek9ZuP+W2xmpvcrHwXZxD5GdieX2dsjPbAbH4azOkrHbycBud2QRU+YQF1CT+pki/lZGedHgo/dQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
+      "engines": {
+        "node": ">= 12.9.0"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -940,6 +963,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
+    "node_modules/helmet": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.0.0.tgz",
+      "integrity": "sha512-MsIgYmdBh460ZZ8cJC81q4XJknjG567wzEmv46WOBblDb6TUd3z8/GhgmsM9pn8g2B80tAJ4m5/d3Bi1KrSUBQ==",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -2213,6 +2244,20 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "node_modules/xss-clean": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/xss-clean/-/xss-clean-0.1.4.tgz",
+      "integrity": "sha512-4hArTFHYxrifK9VXOu/zFvwjTXVjKByPi6woUHb1IqxlX0Z4xtFBRjOhTKuYV/uE1VswbYsIh5vUEYp7MmoISQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "xss-filters": "1.2.7"
+      }
+    },
+    "node_modules/xss-filters": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/xss-filters/-/xss-filters-1.2.7.tgz",
+      "integrity": "sha512-KzcmYT/f+YzcYrYRqw6mXxd25BEZCxBQnf+uXTopQDIhrmiaLwO+f+yLsIvvNlPhYvgff8g3igqrBxYh9k8NbQ=="
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -2734,6 +2779,17 @@
         "busboy": "^1.6.0"
       }
     },
+    "express-mongo-sanitize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/express-mongo-sanitize/-/express-mongo-sanitize-2.2.0.tgz",
+      "integrity": "sha512-PZBs5nwhD6ek9ZuP+W2xmpvcrHwXZxD5GdieX2dsjPbAbH4azOkrHbycBud2QRU+YQF1CT+pki/lZGedHgo/dQ=="
+    },
+    "express-rate-limit": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
+      "requires": {}
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2905,6 +2961,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
+    "helmet": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.0.0.tgz",
+      "integrity": "sha512-MsIgYmdBh460ZZ8cJC81q4XJknjG567wzEmv46WOBblDb6TUd3z8/GhgmsM9pn8g2B80tAJ4m5/d3Bi1KrSUBQ=="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -3855,6 +3916,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "xss-clean": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/xss-clean/-/xss-clean-0.1.4.tgz",
+      "integrity": "sha512-4hArTFHYxrifK9VXOu/zFvwjTXVjKByPi6woUHb1IqxlX0Z4xtFBRjOhTKuYV/uE1VswbYsIh5vUEYp7MmoISQ==",
+      "requires": {
+        "xss-filters": "1.2.7"
+      }
+    },
+    "xss-filters": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/xss-filters/-/xss-filters-1.2.7.tgz",
+      "integrity": "sha512-KzcmYT/f+YzcYrYRqw6mXxd25BEZCxBQnf+uXTopQDIhrmiaLwO+f+yLsIvvNlPhYvgff8g3igqrBxYh9k8NbQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,11 @@
     "express-async-errors": "^3.1.1",
     "express-favicon": "^2.0.4",
     "express-fileupload": "^1.4.0",
+    "express-mongo-sanitize": "^2.2.0",
+    "express-rate-limit": "^6.7.0",
     "fs": "^0.0.1-security",
     "handlebars": "^4.7.7",
+    "helmet": "^7.0.0",
     "http-status-codes": "^2.2.0",
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^7.2.2",
@@ -30,7 +33,8 @@
     "nodemailer": "^6.9.2",
     "path": "^0.12.7",
     "stripe": "^12.10.0",
-    "validator": "^13.9.0"
+    "validator": "^13.9.0",
+    "xss-clean": "^0.1.4"
   },
   "devDependencies": {
     "nodemon": "^2.0.21"

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,12 @@ require('dotenv').config();
 const cookieParser = require('cookie-parser');
 const fileUpload = require('express-fileupload');
 
+//security
+const helmet = require('helmet');
+const xss = require('xss-clean');
+const rateLimiter = require('express-rate-limit');
+const mongoSanitize = require('express-mongo-sanitize');
+
 //app
 
 const mainRouter = require('./routes/mainRouter.js');
@@ -26,6 +32,15 @@ const errorHandlerMiddleware = require('./middleware/error-handler');
 
 app.use(cors());
 app.use(express.json());
+app.use(helmet());
+app.use(xss());
+app.use(mongoSanitize());
+app.use(
+  rateLimiter({
+    windowMs: 60 * 1000, // 15 minutes
+    max: 100, // each IP is limited to make 100 requests per windowMs
+  })
+);
 app.use(express.urlencoded({ extended: false }));
 app.use(logger('dev'));
 app.use(express.static('public'));


### PR DESCRIPTION
Security packages for the backend server have been added:

helmet.js: It helps secure Express apps by setting HTTP response headers.
xss-clean: This middleware sanitizes user input coming from POST body, GET queries and URL parameters.
express-mongo-sanitize: This middleware sanitizes user-supplied data to prevent MongoDB Operator Injection.
express-rate-limit: It is used to limit repeated requests to public APIs and/or endpoints, such as password reset.